### PR TITLE
fixed link of image

### DIFF
--- a/How-to-create-featured-plans.md
+++ b/How-to-create-featured-plans.md
@@ -23,7 +23,7 @@ If you don't know how to enable featured ads please follow [this guide](http://d
 2. **Settings** -> **Payments**, **Add a plan**
 3. Fill the fields and click **Save plan**
 
-![featured plan](../images/featuredplans.png)
+![featured plan](http://docs.yclas.com/images/featuredplans.png)
 
 Now, when a user clicks to feature his/her ad, it will bring him/her to the checkout page to choose which plan he needs to buy.
 


### PR DESCRIPTION
Image wasn't displayed when I opened guide on panel. I changed image's link and it works now.
